### PR TITLE
Tube dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /vendor
 /parameters.yml
+.idea

--- a/src/FlowConfiguration.php
+++ b/src/FlowConfiguration.php
@@ -36,6 +36,7 @@ final class FlowConfiguration implements ConfigurationInterface
                             ->integerNode('max_retry')->min(1)->defaultValue(5)->end()
                         ->end()
                     ->end()
+                    ->arrayNode('depends_on')->scalarPrototype()->end()
                 ->end()
             ->end()
         ;

--- a/src/Model/FlowConfig.php
+++ b/src/Model/FlowConfig.php
@@ -60,4 +60,9 @@ class FlowConfig
     {
         return $this->config['worker']['max_retry'];
     }
+
+    public function getDependsOn(): array
+    {
+        return $this->config['depends_on'];
+    }
 }

--- a/src/NonUtf8Cleaner.php
+++ b/src/NonUtf8Cleaner.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Webgriffe\Esb;
 
-use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Utils;
 
 /**
  * @internal
@@ -12,15 +12,13 @@ class NonUtf8Cleaner
 {
     public static function clean(array $data): array
     {
-        $formatter = new NormalizerFormatter();
-        array_walk_recursive($data, [$formatter, 'detectAndCleanUtf8']);
+        array_walk_recursive($data, [Utils::class, 'detectAndCleanUtf8']);
         return $data;
     }
 
     public static function cleanString(string $data): string
     {
-        $formatter = new NormalizerFormatter();
-        $formatter->detectAndCleanUtf8($data);
+        Utils::detectAndCleanUtf8($data);
         return $data;
     }
 }

--- a/tests/DummyFilesystemWorker.php
+++ b/tests/DummyFilesystemWorker.php
@@ -43,7 +43,9 @@ final class DummyFilesystemWorker implements WorkerInterface
             if (yield File\exists($this->filename)) {
                 $content = yield \Amp\File\get($this->filename);
             }
-            $content .= date('c') . ' - ' . serialize($job->getPayloadData()) . PHP_EOL;
+            //The date() function does not support microseconds, whereas DateTime does.
+            $now = new \DateTime('now');
+            $content .= $now->format('U u') . ' - ' . serialize($job->getPayloadData()) . PHP_EOL;
             yield File\put($this->filename, $content);
         });
     }

--- a/tests/Integration/TwoFlowsDependencyTest.php
+++ b/tests/Integration/TwoFlowsDependencyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\Esb\Integration;
+
+use Amp\Loop;
+use org\bovigo\vfs\vfsStream;
+use Webgriffe\Esb\DummyFilesystemRepeatProducer;
+use Webgriffe\Esb\DummyFilesystemWorker;
+use Webgriffe\Esb\KernelTestCase;
+use Webgriffe\Esb\TestUtils;
+
+class TwoFlowsDependencyTest extends KernelTestCase
+{
+    private const FLOW1_CODE = 'two_flows_flow1';
+    private const FLOW2_CODE = 'two_flows_flow2';
+
+    use TestUtils;
+
+    public function testTwoFlowsWithDependencies()
+    {
+        $producerDir1 = vfsStream::url('root/producer_dir_1');
+        $workerFile1 = vfsStream::url('root/worker_1.data');
+        $producerDir2 = vfsStream::url('root/producer_dir_2');
+        $workerFile2 = vfsStream::url('root/worker_2.data');
+
+        self::createKernel([
+            'services' => [
+                'producer1' => ['class' => DummyFilesystemRepeatProducer::class, 'arguments' => [$producerDir1]],
+                'worker1' => ['class' => DummyFilesystemWorker::class,'arguments' => [$workerFile1]],
+
+                'producer2' => ['class' => DummyFilesystemRepeatProducer::class, 'arguments' => [$producerDir2]],
+                'worker2' => ['class' => DummyFilesystemWorker::class,'arguments' => [$workerFile2]],
+            ],
+            'flows' => [
+                self::FLOW1_CODE => [
+                    'description' => 'Two Flows Test Flow 1',
+                    'producer' => ['service' => 'producer1'],
+                    'worker' => ['service' => 'worker1'],
+                ],
+                self::FLOW2_CODE => [
+                    'description' => 'Two Flows Test Flow 2',
+                    'producer' => ['service' => 'producer2'],
+                    'worker' => ['service' => 'worker2'],
+                ]
+            ]
+        ]);
+
+        Loop::delay(
+            200,
+            function () use ($producerDir1, $producerDir2) {
+                touch($producerDir1 . DIRECTORY_SEPARATOR . 'job1');
+                touch($producerDir2 . DIRECTORY_SEPARATOR . 'job2');
+                Loop::delay(200, function () {
+                    Loop::stop();
+                });
+            }
+        );
+
+        self::$kernel->boot();
+
+        $this->assertReadyJobsCountInTube(0, self::FLOW1_CODE);
+        $workerFileLines = $this->getFileLines($workerFile1);
+        $this->assertCount(1, $workerFileLines);
+        $worker1Line = $workerFileLines[0];
+        $this->assertContains('job1', $worker1Line);
+        $matches = [];
+        $this->assertTrue((bool)preg_match('/^(\d+) (\d+).*/', $worker1Line, $matches));
+        $timestamp1 = $matches[1];
+        $timestamp1 += ((float)$matches[2]) / 1000000;
+
+
+        $this->assertReadyJobsCountInTube(0, self::FLOW2_CODE);
+        $workerFileLines = $this->getFileLines($workerFile2);
+        $this->assertCount(1, $workerFileLines);
+        $worker2Line = $workerFileLines[0];
+        $this->assertContains('job2', $worker2Line);
+        $this->assertTrue((bool)preg_match('/^(\d+) (\d+).*/', $worker2Line, $matches));
+        $timestamp2 = $matches[1];
+        $timestamp2 += ((float)$matches[2]) / 1000000;
+
+        //This is hard to read, but it checks that $timestamp1 >= $timestamp2
+        $this->assertGreaterThanOrEqual($timestamp2, $timestamp1);
+    }
+}


### PR DESCRIPTION
This adds the ability to specify an (optional) array of dependencies for each tube.
Whenever a job is ready to be worked, before starting to process the job each dependency is checked. The job is worked only when ALL dependency tubes are empty.

There seem to be stuff related to ElasticSearch in master, so I created this branch starting from the last tag, plus a couple of cherry-picked commits.