### PR TITLE
Improve jobs count in console home page using Elasticsearch count API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/property-info": "^4.3",
         "doctrine/annotations": "^1.8",
         "ramsey/uuid": "^3.8",
-        "webgriffe/amp-elasticsearch": "^1.0"
+        "webgriffe/amp-elasticsearch": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Console/Controller/IndexController.php
+++ b/src/Console/Controller/IndexController.php
@@ -43,11 +43,8 @@ class IndexController extends AbstractController
     {
         return call(function () use ($flowCode) {
             try {
-                $response = yield $this->getElasticsearch()->getClient()->search(
-                    ['match_all' => new \stdClass()],
-                    $flowCode
-                );
-                return $response['hits']['total']['value'];
+                $response = yield $this->getElasticsearch()->getClient()->count($flowCode);
+                return $response['count'];
             } catch (AmpElasticsearchError $e) {
                 if ($this->isIndexNotFoundException($e)) {
                     return 0;
@@ -61,11 +58,12 @@ class IndexController extends AbstractController
     {
         return call(function () use ($flowCode) {
             try {
-                $response = yield $this->getElasticsearch()->getClient()->search(
-                    ['term' => ['lastEvent.type.keyword' => 'errored']],
-                    $flowCode
+                $response = yield $this->getElasticsearch()->getClient()->count(
+                    $flowCode,
+                    [],
+                    ['term' => ['lastEvent.type.keyword' => 'errored']]
                 );
-                return $response['hits']['total']['value'];
+                return $response['count'];
             } catch (AmpElasticsearchError $e) {
                 if ($this->isIndexNotFoundException($e)) {
                     return 0;
@@ -79,11 +77,12 @@ class IndexController extends AbstractController
     {
         return call(function () use ($flowCode) {
             try {
-                $response = yield $this->getElasticsearch()->getClient()->search(
-                    ['term' => ['lastEvent.type.keyword' => 'worked']],
-                    $flowCode
+                $response = yield $this->getElasticsearch()->getClient()->count(
+                    $flowCode,
+                    [],
+                    ['term' => ['lastEvent.type.keyword' => 'worked']]
                 );
-                return $response['hits']['total']['value'];
+                return $response['count'];
             } catch (AmpElasticsearchError $e) {
                 if ($this->isIndexNotFoundException($e)) {
                     return 0;


### PR DESCRIPTION
Before this PR the jobs count in the console home page was implemented using the Elasticsearch `search` API. This is not the best way to do this. Moreover, by default ES configuration, there's a limit of 10000 documents returned by any search query.

With this PR the jobs count in home page is implemented using the Elasticsearch `count` API.