### PR TITLE
Log all reasons from a Amp\MultiReasonException

### DIFF
--- a/tests/Integration/UncaughtExceptionTest.php
+++ b/tests/Integration/UncaughtExceptionTest.php
@@ -2,15 +2,14 @@
 
 namespace Webgriffe\Esb\Integration;
 
+use Monolog\Logger;
 use Webgriffe\Esb\DummyFilesystemWorker;
 use Webgriffe\Esb\DummyRepeatProducer;
+use Webgriffe\Esb\MultiReasonInitFailingWorker;
 use Webgriffe\Esb\KernelTestCase;
 
 class UncaughtExceptionTest extends KernelTestCase
 {
-    /**
-     * @expectedException \Amp\Beanstalk\ConnectException
-     */
     public function testUncaughtExceptionIsLoggedAndThrown()
     {
         self::createKernel([
@@ -27,8 +26,45 @@ class UncaughtExceptionTest extends KernelTestCase
                 ]
             ]
         ]);
-        self::$kernel->boot();
 
-        $this->logHandler()->hasCriticalThatContains('An uncaught exception occurred, ESB will be stopped now!');
+        try {
+            $this->expectException(\Amp\Beanstalk\ConnectException::class);
+            self::$kernel->boot();
+        } finally {
+            $this->assertTrue($this->logHandler()->hasCriticalThatContains('An uncaught exception occurred, ESB will be stopped now!'));
+        }
+    }
+
+    public function testMultiReasonExceptionIsLoggedAndThrown()
+    {
+        self::createKernel([
+            'services' => [
+                DummyRepeatProducer::class => ['class' => DummyRepeatProducer::class, 'arguments' => []],
+                MultiReasonInitFailingWorker::class => [],
+            ],
+            'flows' => [
+                'sample_tube' => [
+                    'description' => 'Flow',
+                    'producer' => ['service' => DummyRepeatProducer::class],
+                    'worker' => ['service' => MultiReasonInitFailingWorker::class],
+                ]
+            ]
+        ]);
+
+        try {
+            $this->expectException(\Amp\MultiReasonException::class);
+            self::$kernel->boot();
+        } finally {
+            $this->assertTrue($this->logHandler()->hasRecordThatPasses(function ($record) {
+                $context = $record['context'];
+                // Verify log message
+                return $record['message'] === 'An uncaught exception occurred, ESB will be stopped now!'
+                        // Verify log context contains all reasons
+                        && isset($context['reasons']) && is_array($context['reasons'])
+                        && count($context['reasons']) === 2
+                        && $context['reasons'][0]['message'] === 'Exception number one'
+                        && $context['reasons'][1]['message'] === 'Exception number two';
+            }, Logger::CRITICAL));
+        }
     }
 }

--- a/tests/MultiReasonInitFailingWorker.php
+++ b/tests/MultiReasonInitFailingWorker.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Webgriffe\Esb;
+
+use Amp\Promise;
+use Amp\Success;
+use Webgriffe\Esb\Model\JobInterface;
+use function Amp\call;
+
+final class MultiReasonInitFailingWorker implements WorkerInterface
+{
+    /**
+     * @return Promise
+     */
+    public function init(): Promise
+    {
+        return Promise\some([
+            call(function () { throw new \Exception('Exception number one'); } ),
+            call(function () { throw new \Exception('Exception number two'); } ),
+        ], 2);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function work(JobInterface $job): Promise
+    {
+        return new Success();
+    }
+}


### PR DESCRIPTION
Instead of logging the message
    "Fatal error: Uncaught Amp\MultiReasonException: Multiple errors encountered; use Amp\MultiReasonException::getReasons() to retrieve the array of exceptions thrown in ~"
log all individual exceptions so you can see what's actually going wrong