### PR TITLE
Add PHP 7.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   - ESB_CONSOLE_PORT=8080 ESB_HTTP_SERVER_PORT=34981 ESB_BEANSTALKD_URL=tcp://127.0.0.1:11300 ES_BASE_URI=http://127.0.0.1:9200

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "~7.2.0|~7.3.0",
+        "php": "~7.2.0|~7.3.0|~7.4.0",
         "ext-pcntl": "*",
         "symfony/dependency-injection": "^3.3",
         "symfony/config": "^3.3",


### PR DESCRIPTION
- Looking at the PHP 7.4 Backward Incompatible Changes and the repositories code, there is no reason to block this version
- All PhpUnit tests run succesful in PHP 7.4
- Running the ESB in an application (development env though) works as intended