### PR TITLE
Fix ElasticSearch bulk index

### DIFF
--- a/src/Service/ElasticSearch.php
+++ b/src/Service/ElasticSearch.php
@@ -133,7 +133,7 @@ class ElasticSearch
     {
         $body = [];
         foreach ($jobs as $job) {
-            $body[] = ['index' => ['_id' => $job->getUuid()]];
+            $body[] = ['index' => ['_id' => $job->getUuid(), '_type' => '_doc']];
             $body[] = (array)$this->normalizer->normalize($job, 'json');
         }
         yield $this->client->bulk($body, $indexName);


### PR DESCRIPTION
Ok, I know the README said ElasticSearch 7 is required. But with this small fix, it seems to be working on 6.8 as well (without breaking anything).

Fixes
esb.ERROR: An error occurred producing/queueing jobs. {"producer":"..name..","last_job_payload_data":{..data..},"error":"An error occurred. Response code: 400
{
    \"error\": {
        \"root_cause\": [
            {
                \"type\": \"action_request_validation_exception\",
                \"reason\": \"Validation Failed: 1: type is missing;\"
    },
    \"status\": 400
}","test":false} []

on ElasticSearch version 6.8.8