### PR TITLE
Fix: max body size option should actually be passed to HttpServer

### DIFF
--- a/src/Service/HttpProducersServer.php
+++ b/src/Service/HttpProducersServer.php
@@ -69,7 +69,7 @@ class HttpProducersServer
             $options = null;
             if ($this->maxBodySize !== null) {
                 $options = new Options();
-                $options->withBodySizeLimit($this->maxBodySize);
+                $options = $options->withBodySizeLimit($this->maxBodySize);
             }
 
             $this->httpServer = new HttpServer(


### PR DESCRIPTION
Error: Max body size option was not honored
Caused by: $options->withMaxBodySize() returns a new instance containing that option, but that instance was not used