### PR TITLE
Add user/password elasticsearch authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/property-info": "^4.3",
         "doctrine/annotations": "^1.8",
         "ramsey/uuid": "^3.8",
-        "webgriffe/amp-elasticsearch": "^2.1",
+        "webgriffe/amp-elasticsearch": "dev-allow-es-authentication",
         "pagerfanta/pagerfanta": "^2.4",
         "symfony/deprecation-contracts": "^2.1",
         "amphp/http-server-form-parser": "^1.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,14 @@ services:
       - "${MAILHOG_WEB_PORT_HOST}:8025"
 
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.0"
+    image: 'elastic/elasticsearch:8.4.2'
     env_file:
       - .env
     environment:
       - "discovery.type=${ES_DISCOVERY_TYPE:-single-node}"
       - "ES_JAVA_OPTS=${ES_JAVA_OPTS:--Xms512m -Xmx512m}"
+      - xpack.security.enabled=true
+      - action.destructive_requires_name= false # because in unit tests setup we delete all indexes, and wildcards and _all are not allowed with security enabled
+      - ELASTIC_PASSWORD=mySecretPassword
     ports:
       - "${ES_PORT_HOST}:9200"

--- a/esb.yml.sample
+++ b/esb.yml.sample
@@ -8,6 +8,8 @@ parameters:
   console_password: password                                                       # Web console password
   console_log_file: /tmp/esb_console.log                                           # Web console server log file
   elasticsearch_base_uri: '%env(string:ES_BASE_URI)%'                              # ElasticSearch base URI (i.e. http://elasticsearch:9200)
+  elasticsearch_user: '%env(string:ES_USER)%'                                      # ElasticSearch base URI (i.e. http://elasticsearch:9200)
+  elasticsearch_password: '%env(string:ES_PASSWORD)%'                              # ElasticSearch base URI (i.e. http://elasticsearch:9200)
 
 services:
   _defaults:

--- a/services.yml
+++ b/services.yml
@@ -50,6 +50,11 @@ services:
   Webgriffe\AmpElasticsearch\Client:
     arguments:
       $baseUri: '%elasticsearch_base_uri%'
+    calls:
+      - method: 'setCredentials'
+        arguments:
+          - '%elasticsearch_user%'
+          - '%elasticsearch_password%'
 
   annotation_reader:
     class: \Doctrine\Common\Annotations\AnnotationReader

--- a/services_test.yml
+++ b/services_test.yml
@@ -8,6 +8,8 @@ parameters:
   console_password: p4ssw0rd
   console_log_file: ~
   elasticsearch_base_uri: '%env(string:ES_BASE_URI)%'
+  elasticsearch_user: '%env(string:ES_USER)%'
+  elasticsearch_password: '%env(string:ES_PASSWORD)%'
 
 imports:
   - { resource: services.yml}

--- a/tests/KernelTestCase.php
+++ b/tests/KernelTestCase.php
@@ -34,6 +34,10 @@ class KernelTestCase extends BeanstalkTestCase
         parent::setUp();
         filesystem(new BlockingDriver());
         $this->esClient = new Client(getenv('ES_BASE_URI') ?: 'http://127.0.0.1:9200');
+        $this->esClient->setCredentials(
+            getenv('ES_USERNAME') ?: 'elastic',
+            getenv('ES_PASSWORD') ?: 'mySecretPassword'
+        );
         $this->elasticSearchReset();
     }
 


### PR DESCRIPTION
This PR makes ESB work when Elasticsearch has security pack enabled and requires authentication with username and password.
